### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Pop\!\_Shop
-[![Translation status](https://l10n.elementary.io/widgets/appcenter/-/svg-badge.svg)](https://l10n.elementary.io/projects/appcenter/?utm_source=widget)
-[![Bountysource](https://www.bountysource.com/badge/tracker?tracker_id=57667267)](https://www.bountysource.com/teams/elementary/issues?tracker_ids=57667267)
 
-An open, pay-what-you-want app store for indie developers. Based on the [Elementary AppCenter](https://github.com/elementary/appcenter)
+A fast and simple software center. Based on [elementary AppCenter](https://github.com/elementary/appcenter)
 
 ![Pop Shop Screenshot](data/screenshot.png?raw=true)
 
@@ -57,6 +55,6 @@ Fake updates with the `-f` flag followed by PackageKit package name, **not** app
 
     io.elementary.appcenter -f inkscape
 
-Load and preview a local AppStream XML metadata file, your local metadata will show up in the featured banner and will also be searchable. Metadata loaded this way will have a `(local)` suffix in it's name.
+Load and preview a local AppStream XML metadata file, your local metadata will be searchable. Metadata loaded this way will have a `(local)` suffix in it's name.
 
     io.elementary.appcenter --load-local /path/to/file.appdata.xml


### PR DESCRIPTION
- elementary is lowercase
- Removed translations and Bountysource badge (pointed to elementary locations)
- Changed description (we're not pay-what-you-want or targeted to indie devs)
- Remove reference to homepage banner