### PR TITLE
Add Pop-styling to updates badge

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -41,7 +41,6 @@
 
 .badge {
     background-color: #d46c13;
-    background-image: none;
     border: none;
     border-radius: 50%;
     box-shadow:
@@ -52,7 +51,6 @@
     margin: 2px;
     min-width: 18px;
     min-height: 18px;
-    text-shadow: none;
 }
 
 .titlebar {

--- a/data/application.css
+++ b/data/application.css
@@ -40,29 +40,19 @@
 }
 
 .badge {
-    background-image:
-        linear-gradient(
-            to bottom,
-            shade (
-                @error_color,
-                1.3
-            ),
-            @error_color
-        );
-    border: 1px solid shade (@error_color, 0.9);
-    border-radius: 12px;
+    background-color: #d46c13;
+    background-image: none;
+    border: none;
+    border-radius: 50%;
     box-shadow:
-        inset 0 0 0 1px alpha (#fff, 0.05),
-        inset 0 1px 0 0 alpha (#fff, 0.25),
-        inset 0 -1px 0 0 alpha (#fff, 0.1),
         0 1px 2px alpha (#000, 0.3);
     color: #fff;
-    font-size: 11px;
+    font-size: 10px;
     font-weight: 700;
     margin: 2px;
     min-width: 18px;
     min-height: 18px;
-    text-shadow: 0 1px 1px alpha (#000, 0.3);
+    text-shadow: none;
 }
 
 .titlebar {


### PR DESCRIPTION
Adds Pop-based styling CSS to the `.badge` class so that the updates badge doesn't look like elementary anymore. As pretty as that is, it doesn't fit with Pop_OS.