### PR TITLE
Tweak .badge margin

### DIFF
--- a/data/application.css
+++ b/data/application.css
@@ -48,7 +48,7 @@
     color: #fff;
     font-size: 10px;
     font-weight: 700;
-    margin: 2px;
+    margin: 4px;
     min-width: 18px;
     min-height: 18px;
 }


### PR DESCRIPTION
This moves the update badge a bit lower down, and away from the top of the headerbar, giving it a bit of breathing room and visually linking it to the "Installed" label.

@cassidyjames Please do a quick review for the appearance of the badge. Since it's a single-line CSS change, this shouldn't need a full review.