### PR TITLE
Refresh the cache when the GUI loads.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -55,6 +55,13 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
     public MainWindow (Gtk.Application app) {
         Object (application: app);
 
+        unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
+        client.notify["task-count"].connect (() => {
+            working = client.task_count > 0;
+        });
+
+        client.update_cache(true);
+
         weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
         default_theme.add_resource_path ("/io/elementary/appcenter/icons");
 
@@ -127,11 +134,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             } catch (Error e) {
                 warning (e.message);
             }
-        });
-
-        unowned AppCenterCore.Client client = AppCenterCore.Client.get_default ();
-        client.notify["task-count"].connect (() => {
-            working = client.task_count > 0;
         });
 
         show.connect (on_view_mode_changed);


### PR DESCRIPTION
Should help prevent blank GUIs when Pop_Shop loads on first run. 

I'm not sure how to go about testing this without spinning an entirely new ISO, so for now, it might be best to test this out and check for any reduction in functionality. If it works correctly, we can look at creating an ISO with this in it to see if it fixes the problem. 

@brs17 re feedback from Cass, things to watch are CPU usage when opening the Pop_Shop GUI.