### PR TITLE
Use abstracted author title on homepage

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -183,7 +183,7 @@ public class AppCenterCore.Package : Object {
 
             _author_title = author;
             if (_author_title == null) {
-                _author_title = _("The %s Developers").printf (get_name ());
+                _author_title = _("%s Developers").printf (get_name ());
             }
 
             return _author_title;

--- a/src/Widgets/Carousel/CarouselItem.vala
+++ b/src/Widgets/Carousel/CarouselItem.vala
@@ -34,7 +34,7 @@ public class AppCenter.Widgets.CarouselItem : Gtk.FlowBoxChild {
         name_label.xalign = 0;
         name_label.get_style_context ().add_class ("h3");
 
-        var category_label = new Gtk.Label (package.component.developer_name);
+        var category_label = new Gtk.Label (package.author_title);
         category_label.valign = Gtk.Align.START;
         category_label.xalign = 0;
         category_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);


### PR DESCRIPTION
This lets us use [the existing logic for author titles](https://github.com/pop-os/shop/blob/3c8f4ff54f15a3cadf9b45880fe92ab76e02b22b/src/Core/Package.vala#L177), which apps like GNOME Builder need since they set a "project group" but not a "developer".

This also drops the "The" from the fallback author name, so the fallbacks look a little cleaner. Upstream PR opened at https://github.com/elementary/appcenter/pull/694 so we should still get translations for free.