### PR TITLE
Ellipsize UrlButton labels

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -583,6 +583,7 @@ namespace AppCenter.Views {
                 icon.valign = Gtk.Align.CENTER;
 
                 var title = new Gtk.Label (label);
+                title.ellipsize = Pango.EllipsizeMode.END;
 
                 var grid = new Gtk.Grid ();
                 grid.column_spacing = 6;


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/611168/39323393-b824446c-4949-11e8-84bc-e6eacb736880.png)

The button wouldn't allow resizing the window smaller than this.

After:
![image](https://user-images.githubusercontent.com/611168/39323359-9a1ce410-4949-11e8-9548-412d194d3d3c.png)
It ellipsizes the label