### PR TITLE
Keyboard Navigation Support

### DIFF
--- a/src/Core/Package.vala
+++ b/src/Core/Package.vala
@@ -56,8 +56,14 @@ public class AppCenterCore.Package : Object {
         }
     }
 
+    public bool was_uninstalled = false;
+
     public bool installed {
         get {
+            if (was_uninstalled) {
+                return false;
+            }
+            
             if (!installed_packages.is_empty) {
                 return true;
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -88,6 +88,13 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
             return false;
         });
 
+        key_press_event.connect ((event) => {
+            if (stack.visible_child == homepage) {
+                homepage.key_press_event (event);
+            }
+            return true;
+        });
+
         search_entry.search_changed.connect (() => trigger_search ());
 
         view_mode.notify["selected"].connect (on_view_mode_changed);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -71,7 +71,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         }
 
         view_mode.selected = homepage_view_id;
-        search_entry.grab_focus_without_selecting ();
 
         var go_back = new SimpleAction ("go-back", null);
         go_back.activate.connect (view_return);
@@ -89,24 +88,23 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         });
 
         key_press_event.connect ((event) => {
-            if (stack.visible_child == homepage) {
-                homepage.key_press_event (event);
+            if (search_entry.has_focus) {
+                if (event.keyval == Gdk.Key.Escape) {
+                    search_entry.text = "";
+                } else if (event.keyval == Gdk.Key.Tab) {
+                    search_entry.has_focus = false;
+                }
+            } else if (event.state == Gdk.ModifierType.CONTROL_MASK && event.keyval == 'f') {
+                search_entry.has_focus = true;
+            } else if (stack.visible_child == homepage) {
+                return homepage.key_press_event (event);
             }
-            return true;
+            return false;
         });
 
         search_entry.search_changed.connect (() => trigger_search ());
 
         view_mode.notify["selected"].connect (on_view_mode_changed);
-
-        search_entry.key_press_event.connect ((event) => {
-            if (event.keyval == Gdk.Key.Escape) {
-                search_entry.text = "";
-                return true;
-            }
-
-            return false;
-        });
 
         return_button.clicked.connect (view_return);
 
@@ -355,7 +353,6 @@ public class AppCenter.MainWindow : Gtk.ApplicationWindow {
         }
 
         search_entry.sensitive = allow_search;
-        search_entry.grab_focus_without_selecting ();
     }
 
     private void view_return () {

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -37,6 +37,7 @@ namespace AppCenter.Views {
         private Gtk.Stack screenshot_stack;
         private Gtk.TextView app_description;
         private Widgets.Switcher screenshot_switcher;
+        private Gtk.ScrolledWindow scrolled;
 
         public AppInfoView (AppCenterCore.Package package) {
             Object (package: package);
@@ -323,7 +324,7 @@ namespace AppCenter.Views {
                 }
             }
 
-            var scrolled = new Gtk.ScrolledWindow (null, null);
+            scrolled = new Gtk.ScrolledWindow (null, null);
             scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
             scrolled.expand = true;
             scrolled.add (grid);
@@ -381,6 +382,10 @@ namespace AppCenter.Views {
                     });
                 });
             }
+        }
+
+        public void scroll (Gtk.ScrollType scroll_type) {
+            scrolled.scroll_child (scroll_type, false);
         }
 
         protected override void update_state (bool first_update = false) {
@@ -625,4 +630,3 @@ namespace AppCenter.Views {
         }
     }
 }
-

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -170,8 +170,7 @@ namespace AppCenter {
             key_press_event.connect((event) => {
                 if (visible_child != category_scrolled) {
                     if (viewing_package) {
-                        navigate_app_info (event.keyval);
-                        return false;
+                        return navigate_app_info (event.keyval);
                     }
 
                     return navigate_application_list (event.keyval);
@@ -187,7 +186,7 @@ namespace AppCenter {
                             show_app_list_for_category (item.app_category);
                         }
 
-                        break;
+                        return true;
                 }
 
                 return false;
@@ -233,7 +232,7 @@ namespace AppCenter {
                 case Gdk.Key.BackSpace:
                     return_clicked ();
 
-                    break;
+                    return true;
                 case Gdk.Key.space:
                     if (selected == -1) {
                         active_child = (Widgets.PackageRow?) child.list_box.get_row_at_index (0);
@@ -254,7 +253,7 @@ namespace AppCenter {
             return false;
         }
 
-        private void navigate_app_info (uint keyval) {
+        private bool navigate_app_info (uint keyval) {
             switch (keyval) {
                 case Gdk.Key.BackSpace:
                     return_clicked ();
@@ -287,6 +286,8 @@ namespace AppCenter {
 
                     break;
             }
+
+            return true;
         }
 
         public void shuffle_featured_apps () {

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -29,9 +29,10 @@ namespace AppCenter {
         private const int HOMEPAGE_MARGIN = 12;
         private const int LABEL_MARGIN = 10;
 
-        private Gtk.FlowBox category_flow;
+        private Widgets.CategoryFlowBox category_flow;
         private Gtk.ScrolledWindow category_scrolled;
         private string current_category;
+        private weak Widgets.PackageRow? active_child;
 
         public bool viewing_package { get; private set; default = false; }
 
@@ -165,6 +166,182 @@ namespace AppCenter {
             });
 
             featured_carousel.package_activated.connect (show_package);
+
+            key_press_event.connect((event) => {
+                if (visible_child != category_scrolled) {
+                    if (viewing_package) {
+                        navigate_app_info (event.keyval);
+                        return false;
+                    }
+
+                    navigate_application_list (event.keyval);
+                    return false;
+                }
+
+                int children = 0;;
+                int position = 0;
+                int children_per_line = (int) category_flow.get_max_children_per_line ();
+                Widgets.CategoryItem? item = category_flow.get_focused (out children, out position);
+                switch (event.keyval) {
+                    case Gdk.Key.Down:
+                    case Gdk.Key.Right:
+                        if (item == null) {
+                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (0);
+                        } else if (position < children) {
+                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (position + 1);
+                        }
+
+                        if (item != null) {
+                            item.has_focus = true;
+                        }
+
+                        break;
+                    case Gdk.Key.Left:
+                    case Gdk.Key.Up:
+                        if (item == null) {
+                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (0);
+                        } else if (position > 0) {
+                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (position - 1);
+                        }
+
+                        if (item != null) {
+                            item.has_focus = true;
+                        }
+
+                        break;
+                    case Gdk.Key.Return:
+                        if (item != null) {
+                            currently_viewed_category = item.app_category;
+                            show_app_list_for_category (item.app_category);
+                        }
+
+                        break;
+                }
+
+                return false;
+            });
+        }
+
+        private void navigate_application_list (uint keyval) {
+            weak Views.AppListView? child = (Views.AppListView?) get_child_by_name (current_category);
+            if (child == null) {
+                return;
+            }
+
+            // -1 means unset, 0 or above means that item has focus.
+            int selected = -1;
+
+            active_child = (Widgets.PackageRow?) child.list_box.get_selected_row ();
+            if (active_child != null) {
+                selected = active_child.get_index ();
+            }
+
+            switch (keyval) {
+                case Gdk.Key.Down:
+                case Gdk.Key.Right:
+                    if (selected == -1) {
+                        active_child = (Widgets.PackageRow?) child.list_box.get_row_at_index (0);
+                    } else {
+                        var tmp = (Widgets.PackageRow?) child.list_box.get_row_at_index (selected + 1);
+                        if (tmp != null) {
+                            active_child = tmp;
+                        }
+                    }
+
+                    child.list_box.select_row (active_child);
+                    active_child.grab_focus ();
+
+                    break;
+                case Gdk.Key.Left:
+                case Gdk.Key.Up:
+                    if (selected == -1) {
+                        active_child = (Widgets.PackageRow?) child.list_box.get_row_at_index (0);
+                    } else {
+                        var tmp = (Widgets.PackageRow?) child.list_box.get_row_at_index (selected - 1);
+                        if (tmp != null) {
+                            active_child = tmp;
+                        }
+                    }
+
+                    child.list_box.select_row (active_child);
+                    active_child.grab_focus ();
+
+                    break;
+                case Gdk.Key.Return:
+                    if (selected != -1) {
+                        var package = active_child.get_package ();
+                        if (package != null) {
+                            child.show_app (package);
+                        }
+                    }
+
+                    break;
+                case Gdk.Key.BackSpace:
+                    return_clicked ();
+
+                    break;
+                case Gdk.Key.space:
+                    if (selected == -1) {
+                        active_child = (Widgets.PackageRow?) child.list_box.get_row_at_index (0);
+                    } else {
+                        var tmp = (Widgets.PackageRow?) child.list_box.get_row_at_index (selected);
+                        if (tmp != null) {
+                            active_child = tmp;
+                        }
+                    }
+
+                    if (active_child != null) {
+                        active_child.action_clicked ();
+                    }
+
+                    break;
+            }
+        }
+
+        private void navigate_app_info (uint keyval) {
+            switch (keyval) {
+                case Gdk.Key.BackSpace:
+                    return_clicked ();
+
+                    break;
+                case Gdk.Key.space:
+                    if (active_child != null) {
+                        active_child.action_clicked ();
+                    }
+
+                    break;
+                case Gdk.Key.o:
+                    if (active_child != null) {
+                        var package = active_child.get_package ();
+                        if (package != null) {
+                            if (package.installed) {
+                                active_child.launch_package_app ();
+                            }
+                        }
+                    }
+
+                    break;
+                case Gdk.Key.Down:
+                    var view = (Views.AppInfoView) visible_child;
+                    view.scroll (Gtk.ScrollType.STEP_DOWN);
+
+                    break;
+                case Gdk.Key.Up:
+                    var view = (Views.AppInfoView) visible_child;
+                    view.scroll (Gtk.ScrollType.STEP_UP);
+
+                    break;
+                case Gdk.Key.Page_Down:
+                    var view = (Views.AppInfoView) visible_child;
+                    view.scroll (Gtk.ScrollType.PAGE_DOWN);
+
+                    break;
+                case Gdk.Key.Page_Up:
+                    var view = (Views.AppInfoView) visible_child;
+                    view.scroll (Gtk.ScrollType.PAGE_UP);
+
+                    break;
+            }
         }
 
         public void shuffle_featured_apps () {
@@ -191,6 +368,7 @@ namespace AppCenter {
         }
 
         public override void return_clicked () {
+            active_child = null;
             if (previous_package != null) {
                 show_package (previous_package);
                 if (current_category != null) {

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -174,42 +174,14 @@ namespace AppCenter {
                         return false;
                     }
 
-                    navigate_application_list (event.keyval);
-                    return false;
+                    return navigate_application_list (event.keyval);
                 }
 
-                int children = 0;;
-                int position = 0;
-                int children_per_line = (int) category_flow.get_max_children_per_line ();
-                Widgets.CategoryItem? item = category_flow.get_focused (out children, out position);
                 switch (event.keyval) {
-                    case Gdk.Key.Down:
-                    case Gdk.Key.Right:
-                        if (item == null) {
-                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (0);
-                        } else if (position < children) {
-                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (position + 1);
-                        }
-
-                        if (item != null) {
-                            item.has_focus = true;
-                        }
-
-                        break;
-                    case Gdk.Key.Left:
-                    case Gdk.Key.Up:
-                        if (item == null) {
-                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (0);
-                        } else if (position > 0) {
-                            item = (Widgets.CategoryItem?) category_flow.get_child_at_index (position - 1);
-                        }
-
-                        if (item != null) {
-                            item.has_focus = true;
-                        }
-
-                        break;
                     case Gdk.Key.Return:
+                        int children = 0;;
+                        int position = 0;
+                        Widgets.CategoryItem? item = category_flow.get_focused (out children, out position);
                         if (item != null) {
                             currently_viewed_category = item.app_category;
                             show_app_list_for_category (item.app_category);
@@ -222,10 +194,10 @@ namespace AppCenter {
             });
         }
 
-        private void navigate_application_list (uint keyval) {
+        private bool navigate_application_list (uint keyval) {
             weak Views.AppListView? child = (Views.AppListView?) get_child_by_name (current_category);
             if (child == null) {
-                return;
+                return false;
             }
 
             // -1 means unset, 0 or above means that item has focus.
@@ -237,34 +209,16 @@ namespace AppCenter {
             }
 
             switch (keyval) {
+                case Gdk.Key.Up:
                 case Gdk.Key.Down:
+                case Gdk.Key.Left:
                 case Gdk.Key.Right:
                     if (selected == -1) {
                         active_child = (Widgets.PackageRow?) child.list_box.get_row_at_index (0);
-                    } else {
-                        var tmp = (Widgets.PackageRow?) child.list_box.get_row_at_index (selected + 1);
-                        if (tmp != null) {
-                            active_child = tmp;
-                        }
+                        child.list_box.select_row (active_child);
+                        active_child.grab_focus ();
+                        return true;
                     }
-
-                    child.list_box.select_row (active_child);
-                    active_child.grab_focus ();
-
-                    break;
-                case Gdk.Key.Left:
-                case Gdk.Key.Up:
-                    if (selected == -1) {
-                        active_child = (Widgets.PackageRow?) child.list_box.get_row_at_index (0);
-                    } else {
-                        var tmp = (Widgets.PackageRow?) child.list_box.get_row_at_index (selected - 1);
-                        if (tmp != null) {
-                            active_child = tmp;
-                        }
-                    }
-
-                    child.list_box.select_row (active_child);
-                    active_child.grab_focus ();
 
                     break;
                 case Gdk.Key.Return:
@@ -296,6 +250,8 @@ namespace AppCenter {
 
                     break;
             }
+
+            return false;
         }
 
         private void navigate_app_info (uint keyval) {
@@ -307,17 +263,6 @@ namespace AppCenter {
                 case Gdk.Key.space:
                     if (active_child != null) {
                         active_child.action_clicked ();
-                    }
-
-                    break;
-                case Gdk.Key.o:
-                    if (active_child != null) {
-                        var package = active_child.get_package ();
-                        if (package != null) {
-                            if (package.installed) {
-                                active_child.launch_package_app ();
-                            }
-                        }
                     }
 
                     break;

--- a/src/Widgets/AbstractAppList.vala
+++ b/src/Widgets/AbstractAppList.vala
@@ -22,7 +22,7 @@ namespace AppCenter {
     public abstract class AbstractAppList : Gtk.Box {
         public signal void show_app (AppCenterCore.Package package);
         protected Gtk.ScrolledWindow scrolled;
-        protected Gtk.ListBox list_box;
+        public Gtk.ListBox list_box;
         protected Gtk.SizeGroup action_button_group;
         protected Gtk.SizeGroup info_grid_group;
         protected uint packages_changing = 0;
@@ -39,7 +39,7 @@ namespace AppCenter {
             list_box.expand = true;
             list_box.activate_on_single_click = true;
             list_box.set_placeholder (alert_view);
-            list_box.set_selection_mode (Gtk.SelectionMode.NONE);
+            list_box.set_selection_mode (Gtk.SelectionMode.SINGLE);
             list_box.set_sort_func ((Gtk.ListBoxSortFunc) package_row_compare);
             list_box.row_activated.connect ((r) => {
                 var row = (Widgets.AppListRow)r;

--- a/src/Widgets/AppContainers/AbstractAppContainer.vala
+++ b/src/Widgets/AppContainers/AbstractAppContainer.vala
@@ -270,7 +270,7 @@ namespace AppCenter {
             package.action_cancellable.cancel ();
         }
 
-        private void launch_package_app () {
+        public void launch_package_app () {
             try {
                 package.launch ();
             } catch (Error e) {
@@ -278,18 +278,20 @@ namespace AppCenter {
             }
         }
 
-        private async void action_clicked () {
-             if (package.update_available) {
-                 yield package.update ();
+        public async void action_clicked () {
+            if (package.update_available) {
+                yield package.update ();
+            } else if (package.installed) {
+                yield uninstall_clicked ();
             } else if (yield package.install ()) {
-                 // Add this app to the Installed Apps View
-                 MainWindow.installed_view.add_app.begin (package);
+                package.was_uninstalled = false;
+                MainWindow.installed_view.add_app.begin (package);
             }
         }
 
         private async void uninstall_clicked () {
             if (yield package.uninstall ()) {
-                // Remove this app from the Installed Apps View
+                package.was_uninstalled = true;
                 MainWindow.installed_view.remove_app.begin (package);
             }
         }

--- a/src/Widgets/CategoryFlowBox.vala
+++ b/src/Widgets/CategoryFlowBox.vala
@@ -54,4 +54,18 @@ public class AppCenter.Widgets.CategoryFlowBox : Gtk.FlowBox {
 
         return item;
     }
+
+    public Widgets.CategoryItem? get_focused (out int children, out int position) {
+        position = 0;
+        var total_children = get_children ();
+        children = (int) total_children.length ();
+        foreach (var widget in total_children) {
+            if (widget.has_focus) {
+                return (Widgets.CategoryItem) widget;
+            }
+            position += 1;
+        }
+
+        return null;
+    }
 }

--- a/src/Widgets/CategoryItem.vala
+++ b/src/Widgets/CategoryItem.vala
@@ -60,6 +60,8 @@ public class AppCenter.Widgets.CategoryItem : Gtk.FlowBoxChild {
         themed_grid.margin = 6;
 
         child = themed_grid;
+        can_focus = true;
+        add_events(Gdk.EventMask.FOCUS_CHANGE_MASK);
 
         tooltip_text = app_category.summary ?? "";
 

--- a/src/Widgets/CategoryItem.vala
+++ b/src/Widgets/CategoryItem.vala
@@ -60,8 +60,6 @@ public class AppCenter.Widgets.CategoryItem : Gtk.FlowBoxChild {
         themed_grid.margin = 6;
 
         child = themed_grid;
-        can_focus = true;
-        add_events(Gdk.EventMask.FOCUS_CHANGE_MASK);
 
         tooltip_text = app_category.summary ?? "";
 

--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -69,5 +69,13 @@ namespace AppCenter.Widgets {
         public bool has_package () {
             return true;
         }
+
+        public void action_clicked () {
+            grid.action_clicked ();
+        }
+
+        public void launch_package_app () {
+            grid.launch_package_app ();
+        }
     }
 }


### PR DESCRIPTION
- App lists are navigatable with the arrow keys
  - If an arrow key is used and no package is selected, select the first app in the list
  - The space key will install the selected package
  - The enter key will open the app info view for the selected package
- App info views also support keyboard navigation now
  - The space key will install / uninstall the app
  - The arrow keys will scroll the view
  - PgUp & PgDn will also scroll the view
- Ctrl + F switches focus to the search
- Backspace returns to previous view