### PR TITLE
Fix the update badge icon

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -128,6 +128,11 @@ namespace AppCenter {
                 var featured_ids = houston.get_app_ids.end (res);
                 Utils.shuffle_array (featured_ids);
                 new Thread<void*> ("update-featured-carousel", () => {
+                    Idle.add (() => {
+                        main_window.homepage_loaded ();
+                        return false;
+                    });
+
                     featured_apps = {};
                     foreach (var package in featured_ids) {
                         var candidate = package + ".desktop";


### PR DESCRIPTION
- It wouldn't show because the homepage_loaded() signal was never executed
- and so the cache was never updated
- and thus the number of updates never displayed

Closes #85 