### PR TITLE
Recover state w/ `dpkg --configure -a` when required

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -188,6 +188,7 @@ public class AppCenterCore.Client : Object {
 
             packages_ids += null;
 
+            yield dpkg_configure_check ();
             results = yield client.install_packages_async (packages_ids, cancellable, cb);
             exit_status = results.get_exit_code ();
         } catch (Error e) {
@@ -213,6 +214,7 @@ public class AppCenterCore.Client : Object {
         try {
             sc.inhibit ();
 
+            yield dpkg_configure_check ();
             var results = yield client.update_packages_async (packages_ids, cancellable, cb);
             exit_status = results.get_exit_code ();
         } catch (Error e) {
@@ -255,6 +257,7 @@ public class AppCenterCore.Client : Object {
                 packages_ids += package.package_id;
             });
 
+            yield dpkg_configure_check ();
             results = yield client.remove_packages_async (packages_ids, true, true, cancellable, cb);
             exit_status = results.get_exit_code ();
         } catch (Error e) {
@@ -454,6 +457,8 @@ public class AppCenterCore.Client : Object {
 
     private async void refresh_updates () {
         task_count++;
+
+        yield dpkg_configure_check ();
 
         try {
             Pk.Results results = yield UpdateManager.get_default ().get_updates (null);

--- a/src/Core/Dpkg.vala
+++ b/src/Core/Dpkg.vala
@@ -1,0 +1,84 @@
+/*
+ * In the event that the package manager is in an incomplete configuration state,
+ * attempt to resolve it.
+ */
+public async int dpkg_configure_check () {
+    var result = 0;
+    var requires_configure = yield dpkg_requires_configure ();
+    if (requires_configure) {
+        result = yield dpkg_configure ();
+    }
+
+    return result;
+}
+
+/*
+ * Sometimes the package manager can be in an incomplete state. This is detected
+ * by checking the output of `dpkg -l` to see if a package's line begins with
+ * the `iF` flag. This indicates that it was installed, but not configured.
+ */
+private async bool dpkg_requires_configure () {
+    SourceFunc callback = dpkg_requires_configure.callback;
+    bool result = false;
+
+    new Thread<bool> ("dpkg_requires_configure", () => {
+        try {
+            var child = new Subprocess.newv ({"dpkg", "-l"}, GLib.Subprocess.STDOUT_PIPE);
+            var stdout = child.get_stdout_pipe ();
+            var buffer = new uint8[8192];
+            ssize_t read = 1;
+            uint8 state = 0;
+            while (read != 0) {
+                read = stdout.read (buffer, null);
+                foreach (uint8 x in buffer[0:read]) {
+                    if (0 == state && '\n' == x) {
+                        state = 1;
+                    } else if (1 == state) {
+                        state = 'i' == x ? 2 : 0;
+                    } else if (2 == state) {
+                        state = 0;
+                        if ('F' == x) {
+                            result = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            child.wait ();
+        } catch (Error e) {
+            stderr.printf ("dpkg -l errored: %s\n", e.message);
+        }
+
+        Idle.add ((owned)callback);
+        return true;
+    });
+
+    yield;
+    return result;
+}
+
+/*
+ * If `dpkg_requires_configure` return `true`, this should be called to fix it.
+ */
+private async int dpkg_configure () {
+    SourceFunc callback = dpkg_configure.callback;
+    int status = 0;
+
+    new Thread<bool> ("dpkg_configure", () => {
+        try {
+            string[] args = {"pkexec", "dpkg", "--configure", "-a"};
+            var child = new Subprocess.newv (args, GLib.Subprocess.NONE);
+            child.wait ();
+            status = child.get_status ();
+        } catch (GLib.Error e) {
+            stderr.printf ("`dpkg --configure -a` errored: %s\n", e.message);
+        }
+
+        Idle.add ((owned)callback);
+        return true;
+    });
+
+    yield;
+    return status;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,6 +7,7 @@ appcenter_files = files(
     'Core/ChangeInformation.vala',
     'Core/Client.vala',
     'Core/ComponentValidator.vala',
+    'Core/Dpkg.vala',
     'Core/Houston.vala',
     'Core/Package.vala',
     'Core/Task.vala',


### PR DESCRIPTION
This might partially fix #26.

This will recover from a scenario where `dpkg --configure -a` is required to fix the state of the package manager. If a line in `dpkg -l`'s output starts with `iF`, `pkexec dpkg --configure -a` will be executed in an attempt to fix the state of the system.

This check is performed before checking for updates, installing packages, removing packages, and updating packages.