### PR TITLE
Implement Screenshot Cache

### DIFF
--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -40,7 +40,7 @@ public class AppCenterCore.Client : Object {
 
     public bool updating_cache { public get; private set; default = false; }
 
-    public AppCenterCore.ScreenshotCache screenshot_cache;
+    public AppCenterCore.ScreenshotCache screenshot_cache { get; construct; }
     public AppCenterCore.Package os_updates { public get; private set; }
     public Gee.TreeSet<AppCenterCore.Package> driver_list { get; construct; }
 
@@ -61,7 +61,7 @@ public class AppCenterCore.Client : Object {
     private SuspendControl sc;
 
     private Client () {
-        screenshot_cache = new AppCenterCore.ScreenshotCache ();
+        Object (screenshot_cache: new AppCenterCore.ScreenshotCache ());
     }
 
     static construct {

--- a/src/Core/Client.vala
+++ b/src/Core/Client.vala
@@ -40,6 +40,7 @@ public class AppCenterCore.Client : Object {
 
     public bool updating_cache { public get; private set; default = false; }
 
+    public AppCenterCore.ScreenshotCache screenshot_cache;
     public AppCenterCore.Package os_updates { public get; private set; }
     public Gee.TreeSet<AppCenterCore.Package> driver_list { get; construct; }
 
@@ -60,7 +61,7 @@ public class AppCenterCore.Client : Object {
     private SuspendControl sc;
 
     private Client () {
-
+        screenshot_cache = new AppCenterCore.ScreenshotCache ();
     }
 
     static construct {

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -7,7 +7,11 @@ public class AppCenterCore.ScreenshotCache {
     private int screenshot_usage;
 
     public ScreenshotCache () {
-        screenshot_path = GLib.Environment.get_user_cache_dir () + "/appcenter/screenshots";
+        screenshot_path = GLib.Environment.get_user_cache_dir ()
+            + "/"
+            + Build.PROJECT_NAME
+            + "/screenshots";
+
         if (GLib.DirUtils.create_with_parents (screenshot_path, 0755) == -1) {
             critical (
                 "Error creating the temporary folder: GFileError #%d",

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -1,0 +1,197 @@
+public class AppCenterCore.ScreenshotCache {
+    private const int MAX_CACHE_SIZE = 100000000;
+
+    public string screenshot_path;
+
+    // Atomic integer for keeping track of the current screenshot usage.
+    private int screenshot_usage;
+
+    public ScreenshotCache () {
+        screenshot_path = GLib.Environment.get_user_cache_dir () + "/appcenter/screenshots";
+        if (GLib.DirUtils.create_with_parents (screenshot_path, 0755) == -1) {
+            critical (
+                "Error creating the temporary folder: GFileError #%d",
+                GLib.FileUtils.error_from_errno (GLib.errno)
+            );
+        }
+
+        new Thread<bool> ("screenshot_cache", () => {
+            cache_removal_event_loop ();
+            return true;
+        });
+    }
+
+    // When `screenshot_usage` exceeds `MAX_CACHE_SIZE`, the oldest files (based on ctime) will be deleted.
+    private void cache_removal_event_loop () {
+        screenshot_usage = summarize_screenshot_usage ();
+        while (true) {
+            if (AtomicInt.get (ref screenshot_usage) > MAX_CACHE_SIZE) {
+                delete_oldest_files ();
+            }
+
+            Thread.usleep (1000000);
+        }
+    }
+
+    // Delete the oldest files in the screenshot cache until the cache is less than the max size.
+    private void delete_oldest_files () {
+        Dir dir = Dir.open (screenshot_path, 0);
+        string? name = null;
+
+        while (AtomicInt.get (ref screenshot_usage) > MAX_CACHE_SIZE) {
+            string? oldest_path = null;
+            time_t oldest_time = 0;
+            while ((name = dir.read_name ()) != null) {
+                string entry = Path.build_filename (screenshot_path, name);
+                Stat fstat = Stat (entry);
+                if (oldest_time == 0 || fstat.st_mtime < oldest_time) {
+                    oldest_time = fstat.st_mtime;
+                    oldest_path = entry;
+                }
+            }
+
+            if (null != oldest_path) {
+                var file = File.new_for_path (oldest_path);
+                try {
+                    FileInfo info = file.query_info ("standard::*", FileQueryInfoFlags.NONE);
+                    var size = (int) info.get_size ();
+                    file.delete ();
+                    AtomicInt.set (ref screenshot_usage, AtomicInt.get (ref screenshot_usage) - size);
+                } catch (Error e) {
+                    stderr.printf ("failed to delete %s: %s\n", oldest_path, e.message);
+                }
+            }
+        }
+    }
+
+    // Get the combined size of the screenshot cache.
+    private int summarize_screenshot_usage () {
+        Dir dir = Dir.open (screenshot_path, 0);
+        string? name = null;
+        int size = 0;
+
+        while ((name = dir.read_name ()) != null) {
+            string entry = Path.build_filename (screenshot_path, name);
+            File file = File.new_for_path (entry);
+            FileInfo info = file.query_info ("standard::*", FileQueryInfoFlags.NONE);
+            size += (int) info.get_size ();
+        }
+
+        return size;
+    }
+
+    /*
+     * Fetches a screenshot in a background thread.
+     * 
+     * A result indicating the success (0) will be returned as the result upon completion.
+     */
+    public async int fetch (string url, out File out_file) {
+        SourceFunc callback = fetch.callback;
+        int ext_pos = url.last_index_of (".");
+        string extension = url.slice ((long) ext_pos, (long) url.length);
+        string file_name = "%02x".printf (url.hash ());
+
+        string path = screenshot_path + "/" + file_name + extension;
+        int result = 0;
+
+        var file = File.new_for_path (path);
+
+        new Thread<bool> ("fetching_screenshot", () => {
+            FileIOStream stream;
+            var session = new Soup.Session ();
+            bool download = true;
+            time_t mtime = 0;
+
+            try {
+                if (file.query_exists ()) {
+                    stream = file.open_readwrite ();
+                    var msg = new Soup.Message ("HEAD", url);
+                    session.send_message (msg);
+
+                    // Compare the mtimes of the header and the existing file.
+                    // If they're the same, we do not need to download it again.
+                    var modified = msg.response_headers.get_one ("Last-Modified");
+                    if (null != modified) {
+                        var time = new Soup.Date.from_string (modified).to_time_t ();
+                        if (Stat (path).st_mtime != time) {
+                            mtime = time;
+                        } else {
+                            download = false;
+                        }
+                    }
+                } else {
+                    stream = file.create_readwrite (FileCreateFlags.NONE);
+                }
+            } catch (Error e) {
+                debug (e.message);
+                result = -1;
+                return true;
+            }
+
+            if (download) {
+                stderr.printf ("downloading %s to %s\n", url, path);
+
+                try {
+                    FileInfo info = file.query_info ("standard::*", FileQueryInfoFlags.NONE);
+                    AtomicInt.set (ref screenshot_usage, AtomicInt.get (ref screenshot_usage) - (int) info.get_size ());
+                } catch (Error e) {
+                    stderr.printf ("unable to get file info of %s\n before downloading: %s\n", path, e.message);
+                }
+
+                var msg = new Soup.Message ("GET", url);
+                session.send_message (msg);
+                var data = msg.response_body.data;
+
+                // Ensure that what was downloaded is an image, before writing it.
+                var content = msg.response_headers.get_one ("Content-Type");
+                if (null != content && content.has_prefix ("image/")) {
+                    var output = stream.output_stream;
+                    try {
+                        size_t written;
+                        output.write_all (data, out written);
+                        AtomicInt.add (ref screenshot_usage, (int) written);
+                        output.close ();
+                    } catch (IOError e) {
+                        try {
+                            file.delete ();
+                        } catch (Error e) {
+                            stderr.printf ("failed to delete %s: %s\n", path, e.message);
+                        }
+
+                        debug (e.message);
+                        result = -1;
+                        return true;
+                    }
+
+                    var modified = msg.response_headers.get_one ("Last-Modified");
+                    if (null != modified) {
+                        mtime = new Soup.Date.from_string (modified).to_time_t ();
+                    }
+                }
+            }
+
+            if (0 != mtime) {
+                set_mtime (path, mtime);
+            }
+
+            Idle.add ((owned)callback);
+            return true;
+        });
+
+        yield;
+        out_file = file;
+        return result;
+    }
+
+    // Used for setting the `Last-Modified` header's value to the screenshot that was downloaded.
+    private void set_mtime (string path, time_t mtime) {
+        Stat fstat = Stat (path);
+
+        var utimbuf = UTimBuf () {
+            actime = fstat.st_atime,
+            modtime = mtime
+        };
+
+        FileUtils.utime (path, utimbuf);
+    }
+}

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -148,7 +148,7 @@ public class AppCenterCore.ScreenshotCache {
      * 
      * A result indicating the success (0) will be returned as the result upon completion.
      */
-    public async int fetch (string url, out File out_file) {
+    public async int fetch (string url, out string out_file) {
         SourceFunc callback = fetch.callback;
         int result = 0;
         string path = generate_screenshot_path (url);
@@ -248,7 +248,7 @@ public class AppCenterCore.ScreenshotCache {
         });
 
         yield;
-        out_file = file;
+        out_file = path;
         return result;
     }
 

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -23,7 +23,7 @@ public class AppCenterCore.ScreenshotCache {
     // Prune the cache directory if it exceeds the `MAX_CACHE_SIZE`.
     public void maintain () {
         var screenshot_usage = summarize_screenshot_usage ();
-        if (screenshot_usage != -1) {
+        if (screenshot_usage == -1) {
             return;
         }
 

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -2,6 +2,7 @@ public class AppCenterCore.ScreenshotCache {
     private const int MAX_CACHE_SIZE = 100000000;
 
     public string screenshot_path;
+    private Soup.Session session;
 
     public ScreenshotCache () {
         screenshot_path = Path.build_filename (
@@ -10,6 +11,9 @@ public class AppCenterCore.ScreenshotCache {
             Build.PROJECT_NAME,
             "screenshots"
         );
+
+        session = new Soup.Session ();
+        session.timeout = 5;
 
         debug ("screenshot path is at %s\n", screenshot_path);
         if (GLib.DirUtils.create_with_parents (screenshot_path, 0755) == -1) {
@@ -155,9 +159,6 @@ public class AppCenterCore.ScreenshotCache {
         var file = File.new_for_path (path);
 
         new Thread<bool> ("fetching_screenshot", () => {
-            var session = new Soup.Session ();
-            session.timeout = 10;
-
             FileIOStream stream;
             bool download = true;
             time_t mtime = 0;

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -213,24 +213,29 @@ public class AppCenterCore.ScreenshotCache {
 
                 // Ensure that what was downloaded is an image, before writing it.
                 var content = msg.response_headers.get_one ("Content-Type");
-                if (null != content && content.has_prefix ("image/")) {
-                    var output = stream.output_stream;
-                    try {
-                        size_t written;
-                        output.write_all (data, out written);
-                        output.close ();
-                    } catch (IOError e) {
-                        warning ("failed to write image to %s: %s\n", path, e.message);
-                        delete_file (file, path);
-                        result = -1;
-                        Idle.add ((owned)callback);
-                        return true;
-                    }
+                if (content == null || ! content.has_prefix ("image/")) {
+                    warning ("fetched url is not of the image content type");
+                    result = 1;
+                    Idle.add ((owned)callback);
+                    return true;
+                }
 
-                    var modified = msg.response_headers.get_one ("Last-Modified");
-                    if (null != modified) {
-                        mtime = new Soup.Date.from_string (modified).to_time_t ();
-                    }
+                var output = stream.output_stream;
+                try {
+                    size_t written;
+                    output.write_all (data, out written);
+                    output.close ();
+                } catch (IOError e) {
+                    warning ("failed to write image to %s: %s\n", path, e.message);
+                    delete_file (file, path);
+                    result = -1;
+                    Idle.add ((owned)callback);
+                    return true;
+                }
+
+                var modified = msg.response_headers.get_one ("Last-Modified");
+                if (null != modified) {
+                    mtime = new Soup.Date.from_string (modified).to_time_t ();
                 }
             }
 

--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -157,6 +157,7 @@ public class AppCenterCore.ScreenshotCache {
         new Thread<bool> ("fetching_screenshot", () => {
             FileIOStream stream;
             var session = new Soup.Session ();
+            session.timeout = 10;
             bool download = true;
             time_t mtime = 0;
 

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -534,17 +534,19 @@ namespace AppCenter.Views {
                     });
                 });
 
-                string?[] screenshot_files = {};
-                int[] results = {};
+                string?[] screenshot_files = new string?[urls.length ()];
+                int[] results = new int[urls.length ()];
                 int completed = 0;
 
                 // Fetch each screenshot in parallel.
-                foreach (var url in urls) {
+                for (int i = 0; i < urls.length (); i++) {
+                    string url = urls.nth_data (i);
                     string? file = null;
+                    int index = i;
 
                     cache.fetch.begin (url, (obj, res) => {
-                        results += cache.fetch.end (res, out file);
-                        screenshot_files += file;
+                        results[index] = cache.fetch.end (res, out file);
+                        screenshot_files[index] = file;
                         completed++;
                     });
                 }

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -549,6 +549,8 @@ namespace AppCenter.Views {
                     });
                 }
 
+                cache.maintain ();
+
                 // TODO: dynamically load screenshots as they become available.
                 while (urls.length () != completed) {
                     Thread.usleep (100000);

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -534,13 +534,13 @@ namespace AppCenter.Views {
                     });
                 });
 
-                File[] screenshot_files = {};
+                string?[] screenshot_files = {};
                 int[] results = {};
                 int completed = 0;
 
                 // Fetch each screenshot in parallel.
                 foreach (var url in urls) {
-                    File? file = null;
+                    string? file = null;
 
                     cache.fetch.begin (url, (obj, res) => {
                         results += cache.fetch.end (res, out file);
@@ -579,10 +579,10 @@ namespace AppCenter.Views {
         }
 
         // We need to first download the screenshot locally so that it doesn't freeze the interface.
-        private void load_screenshot (File fileimage) {
+        private void load_screenshot (string path) {
             var scale_factor = get_scale_factor ();
             try {
-                var pixbuf = new Gdk.Pixbuf.from_file_at_scale (fileimage.get_path (), 800 * scale_factor, 600 * scale_factor, true);
+                var pixbuf = new Gdk.Pixbuf.from_file_at_scale (path, 800 * scale_factor, 600 * scale_factor, true);
                 var image = new Gtk.Image ();
                 image.width_request = 800;
                 image.height_request = 500;

--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -500,7 +500,7 @@ namespace AppCenter.Views {
             }
         }
 
-        public void load_more_content () {
+        public void load_more_content (AppCenterCore.ScreenshotCache cache) {
             new Thread<void*> ("content-loading", () => {
                 app_version.label = package.get_version ();
                 get_app_download_size.begin ();
@@ -534,8 +534,31 @@ namespace AppCenter.Views {
                     });
                 });
 
+                File[] screenshot_files = {};
+                int[] results = {};
+                int completed = 0;
+
+                // Fetch each screenshot in parallel.
                 foreach (var url in urls) {
-                    load_screenshot (url);
+                    File? file = null;
+
+                    cache.fetch.begin (url, (obj, res) => {
+                        results += cache.fetch.end (res, out file);
+                        screenshot_files += file;
+                        completed++;
+                    });
+                }
+
+                // TODO: dynamically load screenshots as they become available.
+                while (urls.length () != completed) {
+                    Thread.usleep (100000);
+                }
+
+                // Load screenshots that were successfully obtained.
+                for (int i = 0; i < urls.length (); i++) {
+                    if (0 == results[i]) {
+                        load_screenshot (screenshot_files[i]);
+                    }
                 }
 
                 Idle.add (() => {
@@ -554,34 +577,7 @@ namespace AppCenter.Views {
         }
 
         // We need to first download the screenshot locally so that it doesn't freeze the interface.
-        private void load_screenshot (string url) {
-            var ret = GLib.DirUtils.create_with_parents (GLib.Environment.get_tmp_dir () + Path.DIR_SEPARATOR_S + ".appcenter", 0755);
-            if (ret == -1) {
-                critical ("Error creating the temporary folder: GFileError #%d", GLib.FileUtils.error_from_errno (GLib.errno));
-            }
-
-            string path = Path.build_path (Path.DIR_SEPARATOR_S, GLib.Environment.get_tmp_dir (), ".appcenter", "XXXXXX");
-            File fileimage;
-            var fd = GLib.FileUtils.mkstemp (path);
-            if (fd != -1) {
-                var source = File.new_for_uri (url);
-                fileimage = File.new_for_path (path);
-                try {
-                    source.copy (fileimage, GLib.FileCopyFlags.OVERWRITE);
-                } catch (Error e) {
-                    debug (e.message);
-                    return;
-                }
-
-                GLib.FileUtils.close (fd);
-            } else {
-                critical ("Error create the temporary file: GFileError #%d", GLib.FileUtils.error_from_errno (GLib.errno));
-                fileimage = File.new_for_uri (url);
-                if (fileimage.query_exists () == false) {
-                    return;
-                }
-            }
-
+        private void load_screenshot (File fileimage) {
             var scale_factor = get_scale_factor ();
             try {
                 var pixbuf = new Gdk.Pixbuf.from_file_at_scale (fileimage.get_path (), 800 * scale_factor, 600 * scale_factor, true);
@@ -690,4 +686,3 @@ namespace AppCenter.Views {
         }
     }
 }
-

--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -196,6 +196,8 @@ namespace AppCenter {
         }
 
         public override void return_clicked () {
+            remove_visible_package ();
+
             if (previous_package != null) {
                 show_package (previous_package);
                 if (current_category != null) {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -44,6 +44,8 @@ public class AppCenter.Views.InstalledView : View {
     }
 
     public override void return_clicked () {
+        remove_visible_package ();
+
         if (previous_package != null) {
             show_package (previous_package);
             subview_entered (C_("view", "Installed"), false, null);

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -43,6 +43,8 @@ public class AppCenter.Views.SearchView : View {
     }
 
     public override void return_clicked () {
+        remove_visible_package ();
+
         if (viewing_package) {
             if (previous_package != null) {
                 show_package (previous_package);

--- a/src/Views/View.vala
+++ b/src/Views/View.vala
@@ -49,8 +49,9 @@ public abstract class AppCenter.View : Gtk.Stack {
         app_info_view.show_all ();
         add_named (app_info_view, package.component.id);
         set_visible_child (app_info_view);
+        var cache = AppCenterCore.Client.get_default ().screenshot_cache;
         Timeout.add (transition_duration, () => {
-            app_info_view.load_more_content ();
+            app_info_view.load_more_content (cache);
             return Source.REMOVE;
         });
     }

--- a/src/Views/View.vala
+++ b/src/Views/View.vala
@@ -56,5 +56,12 @@ public abstract class AppCenter.View : Gtk.Stack {
         });
     }
 
+    public void remove_visible_package () {
+        unowned Gtk.Widget? child = get_visible_child ();
+        if (null != child && child is Views.AppInfoView) {
+            child.destroy ();
+        }
+    }
+
     public abstract void return_clicked ();
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -9,6 +9,7 @@ appcenter_files = files(
     'Core/ComponentValidator.vala',
     'Core/Houston.vala',
     'Core/Package.vala',
+    'Core/ScreenshotCache.vala',
     'Core/Task.vala',
     'Core/UpdateManager.vala',
     'Dialogs/RestartDialog.vala',


### PR DESCRIPTION
- Screenshots are now stored in the user's cache directory ($HOME/.cache/appcenter/screenshots/)
- They are also now fetched in parallel
- Their names are chosen as the hash of the originating URL, and the extension.
- When fetched, the `Last-Modified` header is set as the mtime of each file, if found.
- The mtime of each file is compared against the `Last-Modified` header of a HEAD request, to determine when to renew a file.
- The cache is defined to not exceed 100MB. If exceeded, the files with the oldest ctime will be removed, until the cache is under the limit