### PR TITLE
Discard old app info views to save memory

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -196,24 +196,26 @@ namespace AppCenter {
         }
 
         public override void return_clicked () {
-            if (previous_package != null) {
-                show_package (previous_package);
-                if (current_category != null) {
-                    subview_entered (current_category, false, "");
+            remove_visible_package (() => {
+                if (previous_package != null) {
+                    show_package (previous_package);
+                    if (current_category != null) {
+                        subview_entered (current_category, false, "");
+                    } else {
+                        subview_entered (_("Home"), false, "");
+                    }
+                } else if (viewing_package && current_category != null) {
+                    set_visible_child_name (current_category);
+                    viewing_package = false;
+                    subview_entered (_("Home"), true, current_category, _("Search %s").printf (current_category));
                 } else {
-                    subview_entered (_("Home"), false, "");
+                    set_visible_child (category_scrolled);
+                    viewing_package = false;
+                    currently_viewed_category = null;
+                    current_category = null;
+                    subview_entered (null, true);
                 }
-            } else if (viewing_package && current_category != null) {
-                set_visible_child_name (current_category);
-                viewing_package = false;
-                subview_entered (_("Home"), true, current_category, _("Search %s").printf (current_category));
-            } else {
-                set_visible_child (category_scrolled);
-                viewing_package = false;
-                currently_viewed_category = null;
-                current_category = null;
-                subview_entered (null, true);
-            }
+            });
         }
 
         private void show_app_list_for_category (AppStream.Category category) {

--- a/src/Views/InstalledView.vala
+++ b/src/Views/InstalledView.vala
@@ -44,13 +44,15 @@ public class AppCenter.Views.InstalledView : View {
     }
 
     public override void return_clicked () {
-        if (previous_package != null) {
-            show_package (previous_package);
-            subview_entered (C_("view", "Installed"), false, null);
-        } else {
-            set_visible_child (app_list_view);
-            subview_entered (null, false);
-        }
+        remove_visible_package (() => {
+            if (previous_package != null) {
+                show_package (previous_package);
+                subview_entered (C_("view", "Installed"), false, null);
+            } else {
+                set_visible_child (app_list_view);
+                subview_entered (null, false);
+            }
+        });
     }
 
     public async void get_apps () {

--- a/src/Views/SearchView.vala
+++ b/src/Views/SearchView.vala
@@ -43,23 +43,25 @@ public class AppCenter.Views.SearchView : View {
     }
 
     public override void return_clicked () {
-        if (viewing_package) {
-            if (previous_package != null) {
-                show_package (previous_package);
-            } else {
-                set_visible_child (app_list_view);
-                viewing_package = false;
-
-                if (current_category != null) {
-                    subview_entered (_("Search Apps"), true, current_category.name);
+        remove_visible_package (() => {
+            if (viewing_package) {
+                if (previous_package != null) {
+                    show_package (previous_package);
                 } else {
-                    subview_entered (null, true);
+                    set_visible_child (app_list_view);
+                    viewing_package = false;
+
+                    if (current_category != null) {
+                        subview_entered (_("Search Apps"), true, current_category.name);
+                    } else {
+                        subview_entered (null, true);
+                    }
                 }
+            } else {
+                search (current_search_term, null);
+                subview_entered (null, true);
             }
-        } else {
-            search (current_search_term, null);
-            subview_entered (null, true);
-        }
+        });
     }
 
     public void search (string search_term, AppStream.Category? category, bool mimetype = false) {

--- a/src/Views/View.vala
+++ b/src/Views/View.vala
@@ -18,6 +18,8 @@
  * Authored by: Corentin Noël <corentin@elementaryos.org>
  */
 
+public delegate void Fn ();
+
 public abstract class AppCenter.View : Gtk.Stack {
     public signal void subview_entered (string? return_name, bool allow_search, string? custom_header = null, string? custom_search_placeholder = null);
 
@@ -49,10 +51,28 @@ public abstract class AppCenter.View : Gtk.Stack {
         app_info_view.show_all ();
         add_named (app_info_view, package.component.id);
         set_visible_child (app_info_view);
+
         Timeout.add (transition_duration, () => {
             app_info_view.load_more_content ();
             return Source.REMOVE;
         });
+    }
+
+    public void remove_visible_package (Fn before_destroy) {
+        unowned Gtk.Widget? child = get_visible_child ();
+        bool marked = false;
+        if (null != child && child is Views.AppInfoView) {
+            marked = true;
+            Idle.add (() => {
+                child.destroy ();
+                return Source.REMOVE;
+            });
+        }
+
+        before_destroy ();
+        if (marked) {
+            remove (child);
+        }
     }
 
     public abstract void return_clicked ();


### PR DESCRIPTION
When navigating back to the app list, the app view that was previously loaded will remain in memory forever. This will ensure to unload the app view when returning from an app view. This fixes one of the memory issues in the app center, though there's still some memory leaks in the UI.