### PR TITLE
Make AppCenterPackageRow objects non selectable

### DIFF
--- a/src/Widgets/PackageRow.vala
+++ b/src/Widgets/PackageRow.vala
@@ -28,6 +28,8 @@ namespace AppCenter.Widgets {
             grid.changed.connect (() => {
                 changed ();
             });
+
+            selectable = false;
         }
 
         public PackageRow.list (AppCenterCore.Package package, Gtk.SizeGroup? info_size_group, Gtk.SizeGroup? action_size_group, bool show_uninstall = true) {
@@ -36,6 +38,8 @@ namespace AppCenter.Widgets {
             grid.changed.connect (() => {
                 changed ();
             });
+
+            selectable = false;
         }
 
         public bool get_update_available () {


### PR DESCRIPTION
From a UX standpoint, having rows selectable means that you can perform some
action on them while they're selected. There's also often an expectation that
you can select multiple items and perform the same action on all of them at
once. Neither of these statements is true for AppCenterPackageRows, so they
should not be selectable.

At one point we patched out their selectability, but it appears to have been
pulled back in, potentially from a sync with upstream. See discussion on
pop-os/gtk-theme#31