### PR TITLE
Minor changes to CSS for Pop

### DIFF
--- a/data/styles/categories.css
+++ b/data/styles/categories.css
@@ -74,8 +74,8 @@
         ),
         linear-gradient(
             to bottom,
-            @ORANGE_300,
-            @ORANGE_500
+            #F37329,
+            #CC3B02
         );
     border-color: alpha(@ORANGE_900, 0.7);
     color: shade(@ORANGE_100, 1.25);
@@ -91,8 +91,8 @@
     background-image:
         linear-gradient(
             175deg,
-            @LIME_300 5%,
-            @LIME_500
+            @LIME_500 5%,
+            @LIME_700
         );
     border-color: alpha(@LIME_900, 0.7);
     color: white;
@@ -506,27 +506,27 @@
     background-image:
         radial-gradient(
             circle,
-            alpha(@STRAWBERRY_900, 0) 65%,
-            alpha(shade(@STRAWBERRY_900, 0.6), 0.35) 4%
+            alpha(#7A0000, 0) 65%,
+            alpha(shade(#7A0000, 0.6), 0.35) 4%
         ),
         linear-gradient(
             to bottom,
-            alpha(shade(@STRAWBERRY_900, 0.6), 0.8),
-            alpha(shade(@STRAWBERRY_900, 0.6), 0)
+            alpha(shade(#7A0000, 0.6), 0.8),
+            alpha(shade(#7A0000, 0.6), 0)
         ),
         linear-gradient(
             to right,
             transparent,
-            alpha(@STRAWBERRY_300, 0.4) 17%,
+            alpha(#ED5353, 0.4) 17%,
             transparent 28%,
             transparent 40%,
-            alpha(@STRAWBERRY_300, 0.4) 70%,
+            alpha(#ED5353, 0.4) 70%,
             transparent 80%
         ),
         linear-gradient(
             to bottom,
-            @STRAWBERRY_300,
-            @STRAWBERRY_700
+            #ED5353,
+            #A10705
         );
     background-repeat:
         no-repeat,
@@ -542,7 +542,7 @@
         auto 150%,
         auto 60%,
         100px, auto;
-    border-color: alpha(@STRAWBERRY_900, 0.9);
+    border-color: alpha(#7A0000, 0.9);
     box-shadow:
         inset 0 0 0 1px alpha(white, 0.05),
         inset 0 1px 0 0 alpha(white, 0.25),
@@ -550,8 +550,8 @@
         0 3px 2px -1px alpha(black, 0.15),
         0 3px 5px alpha(black, 0.1);
     color: white;
-    text-shadow: 0 1px 2px alpha(@STRAWBERRY_900, 0.5);
-    -gtk-icon-shadow: 0 1px 2px alpha(@STRAWBERRY_900, 0.5);
+    text-shadow: 0 1px 2px alpha(#7A0000, 0.5);
+    -gtk-icon-shadow: 0 1px 2px alpha(#7A0000, 0.5);
 }
 
 .category.writing-language {


### PR DESCRIPTION
This adds the elementary color equivalents to a couple of categories which look better with their colors, rather than using our own Pop colors.

Additionally, it uses darker colors for the Music and Apps categories, to help improve contrast and usability.