### PR TITLE
Add some background protection to Appcenter app listings

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -164,3 +164,7 @@
     color: #252e32;
 }
 
+flowboxchild grid image,
+row grid image {
+  -gtk-icon-shadow: 0 2px 3px alpha(black, 0.3);
+}


### PR DESCRIPTION
New GNOME app icons don't always include a built-in stroke for background
protection. This means that they can sometimes become lost against light-colored
backgrounds and are difficult to see.

This adds a slight icon shadow is certain contexts where such an icon may
become hard to see, such as search results or app listings.

Before this change:
![screenshot from 2019-02-28 10-25-08](https://user-images.githubusercontent.com/5883565/53589954-ee6aad80-3b4d-11e9-9f14-bd5dc24f856f.png)

After:
![screenshot from 2019-02-28 10-25-16](https://user-images.githubusercontent.com/5883565/53589966-f4608e80-3b4d-11e9-9720-ea655a744859.png)
