### PR TITLE
Progressbar labels

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -143,6 +143,11 @@
     color: @banner_fg_color;
 }
 
+.banner progressbar text {
+    padding: 3px;
+    background-color: transparent;
+}
+
 .switcher {
     background-color: transparent;
     border: none;

--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -138,7 +138,8 @@
     opacity: 0.33;
 }
 
-.banner progressbar {
+.banner progressbar,
+.banner progressbar text {
     color: @banner_fg_color;
 }
 


### PR DESCRIPTION
Makes the background of progressbar labels transparent, adds a bit of padding between the label and the progressbar itself, and sets the text color to be the same as other text within the banner.

Fixes pop-os/gtk-theme#364