### PR TITLE
Make stack widgets transparent

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -159,6 +159,10 @@
     opacity: 1;
 }
 
+stack {
+    background-color: transparent;
+}
+
 .terminal {
     background-color: #252e32;
     padding: 12px;


### PR DESCRIPTION
This is different from the upstream theme, and
causes pop-os/gtk-theme#360

Fixes pop-os/gtk-theme#360