### PR TITLE
build(deb): Add libflatpak-dev depends for Repoman

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -33,6 +33,7 @@ Depends: appstream (>= 0.12),
          packagekit,
          repoman,
          libhandy-0.0-0,
+         libflatpak-dev (>= 1.0.7),
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: appstream-data-pop, python3-pyflatpak


### PR DESCRIPTION
Adds a dependency for libflatpak-dev so that the Flatpak page in the new Repoman fork will work.