### PR TITLE
fix(css): Ensure text stays readable

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -141,6 +141,10 @@
     color: @banner_fg_color;
 }
 
+.banner flowboxchild:selected button.text-button label {
+    color: @banner_bg_color;
+}
+
 .banner progressbar text {
     padding: 3px;
     background-color: transparent;


### PR DESCRIPTION
This ensures that the text of the install button stays readable even if the flowboxchild with the buttons ends up selected (e.g. if it is clicked).

Fixes #173