### PR TITLE
Link to correct steam ID

### DIFF
--- a/src/Views/Homepage.vala
+++ b/src/Views/Homepage.vala
@@ -251,7 +251,7 @@ namespace AppCenter {
                 "com.slack.Slack",
                 "org.telegram",
                 "org.gnome.meld",
-                "com.steampowered.steam",
+                "com.valvesoftware.Steam",
                 "net.lutris.Lutris",
                 "com.mattermost.Desktop",
                 "com.visualstudio.code",


### PR DESCRIPTION
This fixes the duplicate steam items and makes steam default to the Pop version

Requires https://github.com/pop-os/steam/pull/2 and https://github.com/pop-os/appstream-data/pull/23