### PR TITLE
Add Text Margins to App Description

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -211,6 +211,7 @@ namespace AppCenter.Views {
             app_description.pixels_below_lines = 3;
             app_description.pixels_inside_wrap = 3;
             app_description.wrap_mode = Gtk.WrapMode.WORD_CHAR;
+            app_description.margin = 8;
 
             var links_grid = new Gtk.Grid ();
             links_grid.column_spacing = 12;


### PR DESCRIPTION
This PR adds margins around the app description so that the text doesn't rest directly against the edges of the TextView.

| **Before** | **After** |
|------|------|
| ![before2](https://user-images.githubusercontent.com/4069415/88681165-909b1600-d0f1-11ea-9adf-c470717f4dc3.png) | ![after2](https://user-images.githubusercontent.com/4069415/88681184-97298d80-d0f1-11ea-92b4-2f10c5cab56a.png) |


