### PR TITLE
fix: Hide extraneous NVIDIA packages

### DIFF
--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -85,6 +85,8 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
             }
 
             if (null != nvidia_version) {
+                if (nvidia_version.contains ("-")) continue;
+
                 int parsed = int.parse (nvidia_version);
 
                 if (latest_nvidia_ver < parsed) {


### PR DESCRIPTION
Take 2

For whatever reason, Vala can parse a string that isn't a number, and return a non-zero number

Fixes #211 