### PR TITLE
Remove Backgrounds from App Text

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -161,10 +161,6 @@
     opacity: 1;
 }
 
-stack {
-    background-color: transparent;
-}
-
 .terminal {
     background-color: #252e32;
     padding: 12px;
@@ -174,6 +170,10 @@ stack {
 .terminal selection {
     background-color: #93a1a1;
     color: #252e32;
+}
+
+list, stack, textview, textview text {
+    background: transparent;
 }
 
 flowboxchild grid image,


### PR DESCRIPTION
This pull request removes the off-color background that surrounds the app description and changelog for each app.

| | Before  | After |
| ------------- | ------------- | ------------- |
| Light | ![before_discord](https://user-images.githubusercontent.com/4069415/92335789-af021300-f09a-11ea-8ba6-0c5ae0cf86d9.png) | ![after_discord](https://user-images.githubusercontent.com/4069415/92335794-b9241180-f09a-11ea-8a91-f5e25c6905d7.png) |
| Dark | ![before_discord_dark](https://user-images.githubusercontent.com/4069415/92335798-c5a86a00-f09a-11ea-8d67-3285e4592783.png) | ![after_discord_dark](https://user-images.githubusercontent.com/4069415/92335804-cfca6880-f09a-11ea-970d-82bcc8ca1ac0.png) |