### PR TITLE
fix: Hide NVIDIA drivers which do not have a Pop origin

### DIFF
--- a/src/Core/UbuntuDriversBackend.vala
+++ b/src/Core/UbuntuDriversBackend.vala
@@ -41,6 +41,27 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
         return command.get_exit_status () == 0;
     }
 
+#if POP_OS
+    // A package has Pop packaging if the source is from the Pop PPA.
+    private async bool packaged_by_pop (Cancellable? cancellable = null, string package) {
+        string? output = null;
+        string? drivers_exec_path = Environment.find_program_in_path ("sh");
+        if (drivers_exec_path == null) {
+            return false;
+        }
+
+        Subprocess command;
+        try {
+            command = new Subprocess (SubprocessFlags.STDOUT_PIPE, drivers_exec_path, "-c", "apt-cache policy %s | grep 'ppa.launchpad.net/system76/pop/ubuntu'".printf(package));
+            yield command.communicate_utf8_async (null, cancellable, out output, null);
+        } catch (Error e) {
+            return false;
+        }
+
+        return command.get_exit_status () == 0;
+    }
+#endif
+
     public async Gee.Collection<Package> get_installed_applications (Cancellable? cancellable = null) {
         if (cached_packages != null) {
             return cached_packages;
@@ -72,6 +93,7 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
 
             string[] parts = token.split(",");
             unowned string package_name = parts[0];
+#if POP_OS
             if (package_name.has_prefix ("backport-") && package_name.has_suffix ("-dkms")) {
                 continue;
             }
@@ -87,6 +109,10 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
             if (null != nvidia_version) {
                 if (nvidia_version.contains ("-")) continue;
 
+                if (!yield packaged_by_pop (cancellable, package_name)) {
+                    continue;
+                }
+
                 int parsed = int.parse (nvidia_version);
 
                 if (latest_nvidia_ver < parsed) {
@@ -96,6 +122,7 @@ public class AppCenterCore.UbuntuDriversBackend : Backend, Object {
 
                 continue;
             }
+#endif
 
             cached_packages.add (add_driver (package_name));
         }


### PR DESCRIPTION
Since origin info is not available from the output of `ubuntu-drivers list`, I'm using a grep of `apt-cache policy` output to see if the package is available from us. I'm wondering if there's a better approach.

- `apt-cache show nvidia-driver-440` does not show any packages with a Pop origin
- `apt-cache policy nvidia-driver-440` does show a preferred package with `http://ppa.launchpad.net/system76/pop/ubuntu`
