### PR TITLE
Remove Text Selection on Package Summary

### DIFF
--- a/src/Views/AppInfoView.vala
+++ b/src/Views/AppInfoView.vala
@@ -179,6 +179,7 @@ namespace AppCenter.Views {
             package_name.ellipsize = Pango.EllipsizeMode.MIDDLE;
             package_name.selectable = true;
             package_name.xalign = 0;
+            package_name.can_focus = false;
             package_name.get_style_context ().add_class (Granite.STYLE_CLASS_H1_LABEL);
 
             app_version = new Gtk.Label (null);
@@ -192,6 +193,7 @@ namespace AppCenter.Views {
             package_author.selectable = true;
             package_author.xalign = 0;
             package_author.valign = Gtk.Align.START;
+            package_author.can_focus = false;
             package_author.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
             package_author.get_style_context ().add_class (Granite.STYLE_CLASS_H3_LABEL);
 
@@ -202,6 +204,7 @@ namespace AppCenter.Views {
             package_summary.wrap = true;
             package_summary.wrap_mode = Pango.WrapMode.WORD_CHAR;
             package_summary.valign = Gtk.Align.CENTER;
+            package_summary.can_focus = false;
 
             app_description = new Gtk.TextView ();
             app_description.expand = true;


### PR DESCRIPTION
This PR prevents the package name, author, and summary from being focused when clicked. The text remains selectable but this prevents a text-editing cursor from appearing on the read-only label when it's clicked.

Note that the comparison only shows the change on the package summary.

| **Before** | **After** |
|------------|------------|
| ![pop_selection_micro_before](https://user-images.githubusercontent.com/4069415/94149522-4d062380-fe78-11ea-8bae-78ce1019e116.gif) | ![pop_selection_micro_after](https://user-images.githubusercontent.com/4069415/94149548-555e5e80-fe78-11ea-8e83-e10db3cbf8ad.gif) |