### PR TITLE
Disable User Selection on Layout Grids

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -150,6 +150,10 @@
     background-color: transparent;
 }
 
+grid {
+    outline: none;
+}
+
 .switcher {
     background-color: transparent;
     border: none;


### PR DESCRIPTION
This PR prevents an outline from appearing around layout grids when clicked.

| **Before** |
|------------|
| ![pop_grid_selectable_before](https://user-images.githubusercontent.com/4069415/94150259-2dbbc600-fe79-11ea-8e71-d8ed82392641.gif) |

| **After** |
|------------|
| ![pop_grid_selectable_after](https://user-images.githubusercontent.com/4069415/94150276-344a3d80-fe79-11ea-9941-45b2d24836b5.gif) |