### PR TITLE
fix: Use systemd timer for update checks to eliminate background RAM usage

### DIFF
--- a/data/io.elementary.appcenter.service.in
+++ b/data/io.elementary.appcenter.service.in
@@ -1,0 +1,8 @@
+[Unit]
+Description=Check for package updates, and notify that updates are available
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/@PROJECT_NAME@/update-check.sh

--- a/data/io.elementary.appcenter.timer
+++ b/data/io.elementary.appcenter.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Check for package updates daily
+
+[Timer]
+OnCalendar=daily
+OnActiveSec=10
+
+[Install]
+WantedBy=timers.target

--- a/data/io.elementary.appcenter.update-check.sh.in
+++ b/data/io.elementary.appcenter.update-check.sh.in
@@ -1,0 +1,36 @@
+#!/bin/sh
+
+flatpak update --appstream
+
+UPDATES_AVAILABLE=0
+
+if pkcon get-updates -p | grep 'Package:' > /dev/null; then
+    UPDATES_AVAILABLE=1
+fi
+
+if ! flatpak remote-ls --updates > /dev/null; then
+    UPDATES_AVAILABLE=1
+fi
+
+if test "${UPDATES_AVAILABLE}" = 1; then
+    gdbus call --session \
+        --dest=org.freedesktop.Notifications \
+        --object-path=/org/freedesktop/Notifications \
+        --method=org.freedesktop.Notifications.Notify \
+        "system-software-install" 0 "" "Updates available to install" \
+        "Install system and application updates for Pop!_OS" \
+        "['default', '']" \
+        '{"urgency": <1>}' \
+        5000
+
+    timeout 5 gdbus monitor --session \
+        --dest=org.freedesktop.Notifications \
+        --object-path=/org/freedesktop/Notifications | {
+            while IFS= read -r line; do
+                if echo $line | grep ActionInvoked; then
+                    @EXEC_NAME@ --show-updates
+                    break
+                fi
+            done
+        }
+fi

--- a/data/meson.build
+++ b/data/meson.build
@@ -19,12 +19,26 @@ install_data(
     rename: meson.project_name() + '-symbolic.svg'
 )
 
-# Daemon Desktop file (for GNOME Session autostart)
+# Script to check for updates
 configure_file(
-    input: meson.project_name() + '-daemon.desktop.in',
-    output: meson.project_name() + '-daemon.desktop',
+    input: meson.project_name() + '.update-check.sh.in',
+    output: 'update-check.sh',
     configuration: conf_data,
-    install_dir: join_paths(get_option('datadir'), 'applications')
+    install_dir: join_paths (get_option('prefix'), '/usr/lib', meson.project_name())
+)
+
+# Systemd service for that script
+configure_file(
+    input: meson.project_name() + '.service.in',
+    output: meson.project_name() + '.service',
+    configuration: conf_data,
+    install_dir: join_paths (get_option('prefix'), '/usr/lib/systemd/user')
+)
+
+# Systemd timer for that service
+install_data(
+    meson.project_name() + '.timer',
+    install_dir: join_paths (get_option('prefix'), '/usr/lib/systemd/user')
 )
 
 # GNOME Shell Search Provider

--- a/debian/control
+++ b/debian/control
@@ -34,6 +34,7 @@ Depends: appstream (>= 0.12),
          apt-config-icons-large,
          apt-config-icons-large-hidpi,
          packagekit,
+         packagekit-tools,
          repoman,
          ${misc:Depends},
          ${shlibs:Depends}

--- a/debian/pop-shop.install
+++ b/debian/pop-shop.install
@@ -1,5 +1,6 @@
 etc/
 usr/bin/
+usr/lib/
 usr/share/applications/
 usr/share/glib-2.0/
 usr/share/gnome-shell/search-providers/

--- a/debian/pop-shop.links
+++ b/debian/pop-shop.links
@@ -1,1 +1,0 @@
-usr/share/applications/io.elementary.appcenter-daemon.desktop etc/xdg/autostart/io.elementary.appcenter-daemon.desktop

--- a/debian/pop-shop.postinst
+++ b/debian/pop-shop.postinst
@@ -1,0 +1,1 @@
+systemctl --global enable io.elementary.appcenter.timer


### PR DESCRIPTION
Uses a systemd timer and a shell script to check for updates daily. On an update being found, a notification is displayed that will open the shop to the updates view on activation of the notification. This should stop reports of the shop using 2 GB RAM in the background when not in use.