### PR TITLE
Workaround screenshot fetch failing for packages like Popsicle

### DIFF
--- a/src/Core/ScreenshotCache.vala
+++ b/src/Core/ScreenshotCache.vala
@@ -192,11 +192,6 @@ public class AppCenterCore.ScreenshotCache : GLib.Object {
             warning ("Error getting modification time of remote screenshot file: %s", e.message);
         }
 
-        if (remote_mtime == null) {
-            // Used the locally cached version if it exists
-            return local_file.query_exists ();
-        }
-
         if (local_file.query_exists ()) {
             GLib.DateTime? file_time = null;
             try {
@@ -207,7 +202,7 @@ public class AppCenterCore.ScreenshotCache : GLib.Object {
             }
 
             // Local file is up to date
-            if (file_time != null && file_time.equal (remote_mtime)) {
+            if (file_time != null && remote_mtime != null && file_time.equal (remote_mtime)) {
                 return true;
             }
         }


### PR DESCRIPTION
See https://github.com/elementary/appcenter/issues/1537

Without this screenshots for Popsicle fail to load (unless already cached in `~/.cache/io.elementary.appcenter`).

This should fix that, at the cost of having to download the screenshots each time since the cache doesn't know when the remote copy was last updated.