### PR TITLE
fix(css): ensure that text buttons in selected rows remain legible

### DIFF
--- a/data/styles/application.css
+++ b/data/styles/application.css
@@ -185,3 +185,7 @@ flowboxchild grid image,
 row grid image {
   -gtk-icon-shadow: 0 2px 3px alpha(black, 0.3);
 }
+
+row.activatable button.text-button > label {
+    color: @theme_fg_color;
+  }


### PR DESCRIPTION
Currently in a dark theme (with dark button backgrounds), when a selected
row has a button on it, the text within that button is dark colored. With
this patch, the text should be colored based on what the theme specifies
for foreground text (usually "black" on light themes and "white" on
light themes) so that the text remains readable on dark
button backgrounds.

It was decided to make this change within the Pop_Shop codebase instead of against the theme because I can't find any instances of buttons with dark backgrounds on selected activatable rows anywhere else in our default apps which leads me to believe this is a pattern specific to Pop_Shop, but I can modify this there instead if I missed something. 

Fixes pop-os/gtk-theme#516