### PR TITLE
Fix Update-Menu Hot-key not working

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -238,6 +238,7 @@ public class AppCenter.App : Gtk.Application {
         add_action (repair_action);
         set_accels_for_action ("app.quit", {"<Control>q"});
         set_accels_for_action ("app.refresh", {"<Control>r"});
+        set_accels_for_action("app.show-updates", {"<Control>i"});
 #if POP_OS
         add_action (auto_action);
         set_accels_for_action ("app.auto", {"<Control>u"}); // "a" for "auto" conflicts with the search box


### PR DESCRIPTION
The Hambuger Menu shows that you should be able to press `<Ctrl>-i` and have the 'Updates & Installed Software' screen appear. Add this functionality in, as it seems to have been forgotten

Fixes #420 